### PR TITLE
Check preferredPalette for extent

### DIFF
--- a/src/layers/PaletteMixin.js
+++ b/src/layers/PaletteMixin.js
@@ -66,6 +66,9 @@ export function PaletteMixin (base) {
         this._palette = options.palette
       } else if (parameter.preferredPalette) {
         this._palette = paletteFromObject(parameter.preferredPalette)
+        if (parameter.preferredPalette.extent) {
+          this._paletteExtent = parameter.preferredPalette.extent
+        }
       } else if (categories) {
         if (categories.every(cat => cat.preferredColor)) {
           this._palette = directPalette(categories.map(cat => cat.preferredColor))


### PR DESCRIPTION
Palette can currently be specified for parameters using `preferredPalette`.  This change let's the palette define its extent in case that differs from the coverage extent.

```
{
  colors: [
    'rgb(255, 255, 255)', // 0
    'rgb(255, 255, 255)', // 1
    'rgb(191, 204, 255)', // 2
    'rgb(160, 230, 255)', // 3
    'rgb(128, 255, 255)', // 4
    'rgb(122, 255, 147)', // 5
    'rgb(255, 255, 0)', // 6
    'rgb(255, 200, 0)', // 7
    'rgb(255, 145, 0)', // 8
    'rgb(255, 0, 0)', // 9
    'rgb(200, 0, 0)' // 10
  ],
  extent: [0, 10],
  interpolation: 'linear'
}
```